### PR TITLE
Fix: to close run after all attachments are uploaded

### DIFF
--- a/index.js
+++ b/index.js
@@ -187,10 +187,14 @@ module.exports = (config) => {
 		}
 
 		await _publishResultsToTestrail();
+		await _closeTestRun();
 	});
 
 	event.dispatcher.on(event.all.result, async () => {
-		if (!process.env.RUNS_WITH_WORKERS) await _publishResultsToTestrail();
+		if (!process.env.RUNS_WITH_WORKERS) {
+			await _publishResultsToTestrail();
+			await _closeTestRun();
+		}
 	});
 
 	async function _publishResultsToTestrail() {
@@ -357,17 +361,19 @@ module.exports = (config) => {
 								}
 							});
 						});
-
-						if (config.closeTestRun === true) {
-							testrail.closeTestRun(runId).then(res => {
-								output.log(`The run ${runId} is updated with ${JSON.stringify(res)}`);
-							});
-						}
 					});
 				}
 			});
 		} else {
 			output.log('There is no TC, hence no test run is created');
+		}
+	}
+
+	async function _closeTestRun() {
+		if (config.closeTestRun === true) {
+			testrail.closeTestRun(runId).then(res => {
+				output.log(`The run ${runId} is updated with ${JSON.stringify(res)}`);
+			});
 		}
 	}
 


### PR DESCRIPTION
We are using testrail and codeceptjs and I noticed, that screenshots are not uploaded after test runs with failures
After debugging I found out that there is an error message "'This operation is not allowed. The test run is already completed." when upload of artifacts is performed, that indicates that requests for upload and closing are done simultaneously. So I've splitted these functions and suggest to do upload first and closing test run after.

Before:
<img width="623" alt="Screenshot 2024-09-26 at 00 10 28" src="https://github.com/user-attachments/assets/a7874cc7-4e18-4305-b00c-9c6c2e4d152b">

After:
<img width="879" alt="Screenshot 2024-09-26 at 00 14 22" src="https://github.com/user-attachments/assets/cea8be3a-0595-4d92-bae7-6f1954940c45">
